### PR TITLE
Add 3D tilt effect to leaderboard card

### DIFF
--- a/script.js
+++ b/script.js
@@ -127,6 +127,36 @@ async function fetchLeaderboard() {
   }
 }
 
+function initTiltEffect() {
+    const card = document.getElementById('leaderboard');
+    const maxTilt = 10; // Maximum tilt angle in degrees
+
+    card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        
+        // Calculate tilt angles based on mouse position
+        const xRatio = (x / rect.width - 0.5) * 2; // -1 to 1
+        const yRatio = (y / rect.height - 0.5) * 2; // -1 to 1
+        
+        // Invert the angles for natural tilting effect
+        const tiltX = -yRatio * maxTilt;
+        const tiltY = xRatio * maxTilt;
+
+        // Apply the transform
+        card.style.transform = `rotateX(${tiltX}deg) rotateY(${tiltY}deg)`;
+    });
+
+    // Reset transform when mouse leaves
+    card.addEventListener('mouseleave', () => {
+        card.style.transform = 'rotateX(0deg) rotateY(0deg)';
+    });
+}
+
+// Call this function after the leaderboard content is loaded
+document.addEventListener('DOMContentLoaded', initTiltEffect);
+
 fetchLeaderboard();
 setInterval(fetchLeaderboard, 30000);
 

--- a/style.css
+++ b/style.css
@@ -97,6 +97,8 @@ h1 {
     margin-bottom: 60px;
     /* adjust if footer height changes */
     padding: 0 20px;
+
+    perspective: 1000px;
 }
 
 /* ================================================================
@@ -109,6 +111,10 @@ h1 {
     border-radius: 10px;
     padding: 15px;
     box-shadow: 0 0 15px rgba(255, 255, 255, 0.05);
+
+    transform-style: preserve-3d;
+    transition: transform 0.1s ease;
+    will-change: transform;
 }
 
 .entry {


### PR DESCRIPTION
This implementation will:

Add perspective to the container for 3D effect
Enable smooth transitions for the transform
Calculate tilt angles based on mouse position
Reset the card position when the mouse leaves
Limit the maximum tilt to 10 degrees

The card will now tilt smoothly as the user moves their mouse over it, creating an interactive 3D effect that makes the leaderboard feel more dynamic and engaging.